### PR TITLE
Fix Rusefi Simulato compilation

### DIFF
--- a/os/various/cpp_wrappers/syscalls_cpp.cpp
+++ b/os/various/cpp_wrappers/syscalls_cpp.cpp
@@ -19,8 +19,8 @@ pid_t _getpid(void){
    return 1;
 }
 
-#undef errno
-extern int errno;
+//#undef errno
+//extern int errno;
 int _kill(int pid, int sig) {
   (void)pid;
   (void)sig;

--- a/os/various/cpp_wrappers/syscalls_cpp.hpp
+++ b/os/various/cpp_wrappers/syscalls_cpp.hpp
@@ -8,6 +8,6 @@ int __cxa_guard_acquire(__guard *);
 void __cxa_guard_release (__guard *);
 void __cxa_guard_abort (__guard *);
 
-void *__dso_handle = NULL;
+//void *__dso_handle = NULL;
 
 #endif /* SYSCALLS_CPP_HPP_ */


### PR DESCRIPTION
This fixes:
build/obj/syscalls_cpp.o:(.bss.__dso_handle+0x0): multiple definition of `__dso_handle'
/usr/lib/gcc/x86_64-linux-gnu/7/32/crtbeginS.o:(.data.rel.local+0x0): first defined here
/usr/bin/ld: errno: TLS definition in /lib32/libc.so.6 section .tbss mismatches non-TLS reference in build/obj/syscalls_cpp.o