### PR TITLE
STM32: PWM: set 32bit mode bit in CR1 register for Artery devices

### DIFF
--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim.h
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim.h
@@ -48,6 +48,9 @@
 #define STM32_TIM_CR1_CKD_MASK              (3U << 8)
 #define STM32_TIM_CR1_CKD(n)                ((n) << 8)
 
+/* Plus Mode Enable - 32 bit mode timer */
+#define AT32_TIM_CR1_PMEN                   (1U << 10)
+
 #define STM32_TIM_CR1_UIFREMAP              (1U << 11)
 /** @} */
 


### PR DESCRIPTION
TODO: add same fix for other TIM drivers