### PR TITLE
4556 RTC: do not reset BKP domain if backup clock source is used

### DIFF
--- a/os/hal/ports/STM32/STM32F0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F0xx/hal_lld.c
@@ -59,8 +59,10 @@ static void hal_lld_backup_domain_init(void) {
   /* Backup domain access enabled and left open.*/
   PWR->CR |= PWR_CR_DBP;
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->BDCR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;
@@ -87,8 +89,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32F37x/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F37x/hal_lld.c
@@ -56,8 +56,10 @@ static void hal_lld_backup_domain_init(void) {
   /* Backup domain access enabled and left open.*/
   PWR->CR |= PWR_CR_DBP;
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->BDCR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;
@@ -84,8 +86,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32F3xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F3xx/hal_lld.c
@@ -56,8 +56,10 @@ static void hal_lld_backup_domain_init(void) {
   /* Backup domain access enabled and left open.*/
   PWR->CR |= PWR_CR_DBP;
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->BDCR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;
@@ -84,8 +86,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32F4xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F4xx/hal_lld.c
@@ -56,8 +56,10 @@ static void hal_lld_backup_domain_init(void) {
   /* Backup domain access enabled and left open.*/
   PWR->CR |= PWR_CR_DBP;
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->BDCR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;
@@ -83,8 +85,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32F7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F7xx/hal_lld.c
@@ -56,8 +56,10 @@ static void hal_lld_backup_domain_init(void) {
   /* Backup domain access enabled and left open.*/
   PWR->CR1 |= PWR_CR1_DBP;
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->BDCR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;
@@ -83,8 +85,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32G0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32G0xx/hal_lld.c
@@ -53,8 +53,10 @@ uint32_t SystemCoreClock = STM32_HCLK;
  */
 static void hal_lld_backup_domain_init(void) {
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->BDCR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;
@@ -81,8 +83,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32G4xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32G4xx/hal_lld.c
@@ -53,8 +53,10 @@ uint32_t SystemCoreClock = STM32_HCLK;
  */
 static void hal_lld_backup_domain_init(void) {
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->BDCR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;
@@ -81,8 +83,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld.c
@@ -56,8 +56,10 @@ static inline void init_bkp_domain(void) {
   /* Backup domain access enabled and left open.*/
   PWR->CR1 |= PWR_CR1_DBP;
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->BDCR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;
@@ -83,8 +85,11 @@ static inline void init_bkp_domain(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32L0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32L0xx/hal_lld.c
@@ -54,8 +54,10 @@ static void hal_lld_backup_domain_init(void) {
   /* Backup domain access enabled and left open.*/
   PWR->CR |= PWR_CR_DBP;
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->CSR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->CSR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->CSR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->CSR |= RCC_CSR_RTCRST;
     RCC->CSR &= ~RCC_CSR_RTCRST;
@@ -76,9 +78,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->CSR & RCC_CSR_RTCEN) == 0) {
     /* Selects clock source.*/
-    RCC->CSR |= STM32_RTCSEL;
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->CSR |= (RCC->CSR & RCC_CSR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->CSR |= (RCC->CSR & RCC_CSR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->CSR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32L1xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32L1xx/hal_lld.c
@@ -56,8 +56,10 @@ static void hal_lld_backup_domain_init(void) {
   /* Backup domain access enabled and left open.*/
   PWR->CR |= PWR_CR_DBP;
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->CSR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->CSR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->CSR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->CSR |= RCC_CSR_RTCRST;
     RCC->CSR &= ~RCC_CSR_RTCRST;
@@ -78,8 +80,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->CSR & RCC_CSR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->CSR |= (RCC->CSR & RCC_CSR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->CSR |= (RCC->CSR & RCC_CSR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->CSR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32L4xx+/hal_lld.c
+++ b/os/hal/ports/STM32/STM32L4xx+/hal_lld.c
@@ -53,8 +53,10 @@ uint32_t SystemCoreClock = STM32_HCLK;
  */
 static void hal_lld_backup_domain_init(void) {
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->BDCR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;
@@ -89,8 +91,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32L4xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32L4xx/hal_lld.c
@@ -53,8 +53,10 @@ uint32_t SystemCoreClock = STM32_HCLK;
  */
 static void hal_lld_backup_domain_init(void) {
 
-  /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  /* Reset BKP domain if different clock source selected.
+     Do not reset if fallback source is selected */
+  if (((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) &&
+      ((RCC->BDCR & STM32_RTCSEL_MASK) != RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL)) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;
@@ -89,8 +91,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+    /* TODO: what should we do if we were able to start primary RTC source while RTC already switched to backuo one?
+       Switching source require reseting whole BKP domain! */
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    /* TODO: here we expect STM32_RTCSEL to be STM32_RTCSEL_LSE */
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) ? STM32_RTCSEL : RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif


### PR DESCRIPTION
BKP clock source can be selected only once.
Changing clock can happen only through domain reset.
ChibiOS checks if correct clock source selected. Extend this check with backup clock source that is LSI for RusEFI boards.
So now if board have no LSE oscillator and LSI is selected as clock source for RTC on next start `hal_lld_backup_domain_init()` will not reset BKP domain.