### PR TITLE
chdebug: pass reason to chSysHalt() in chDbgAssert()

### DIFF
--- a/os/rt/include/chdebug.h
+++ b/os/rt/include/chdebug.h
@@ -129,7 +129,7 @@
   if (CH_DBG_ENABLE_ASSERTS != FALSE) {                                     \
     if (!(c)) {                                                             \
   /*lint -restore*/                                                         \
-      chSysHalt(__func__);                                                  \
+      chSysHalt(r);                                                         \
     }                                                                       \
   }                                                                         \
 } while (false)


### PR DESCRIPTION
Instead of __func__. This should help localize problem but increase binary size.

Currently we have only name of function that causes assert. Some functions (like `_usb_ep0out`) have several `osalDbgAssert`. Lets report `remark` instead of function name.